### PR TITLE
Support async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - The `IntegrationTime` enum now has `as_ms` and `as_us` methods
-- `async` support via `maybe-async`
+- `async` support via the `maybe-async-cfg` crate and `embedded-hal-async`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - The `IntegrationTime` enum now has `as_ms` and `as_us` methods
+- `async` support via `maybe-async`
+
+### Changed
+
+- bump `embedded-hal` to 1.0.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- bump `embedded-hal` to 1.0.0
-- bump `libm` to 0.2
-- bump `linux-embedded-hal` to 0.4
-
-### Changed
+- Bump `embedded-hal` to 1.0.0
+- Bump `libm` to 0.2
+- Bump `linux-embedded-hal` to 0.4
 
 - Upgrade MSRV to 1.75.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - bump `embedded-hal` to 1.0.0
+- bump `libm` to 0.2
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - bump `embedded-hal` to 1.0.0
 - bump `libm` to 0.2
+- bump `linux-embedded-hal` to 0.4
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,15 @@ edition = "2018"
 [badges]
 coveralls = { repository = "eldruin/veml6030-rs", branch = "master", service = "github" }
 
+[features]
+default = []
+async = ["dep:embedded-hal-async"]
+
 [dependencies]
 embedded-hal = "1.0"
+embedded-hal-async = { version = "1.0.0", optional = true }
 libm = "0.1"
+maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async = ["dep:embedded-hal-async"]
 [dependencies]
 embedded-hal = "1.0"
 embedded-hal-async = { version = "1.0.0", optional = true }
-libm = "0.1"
+libm = "0.2"
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.7"
+embedded-hal-mock = "0.11.1"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 coveralls = { repository = "eldruin/veml6030-rs", branch = "master", service = "github" }
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = "1.0"
 libm = "0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
-embedded-hal-mock = "0.11.1"
+embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }
+tokio = { version = "1.45.1", features = ["rt", "macros"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ libm = "0.2"
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
+linux-embedded-hal = "0.4"
 embedded-hal-mock = "0.11.1"
 
 [profile.release]

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -3,7 +3,7 @@ use crate::{
     calculate_raw_threshold_value, Config, Error, FaultCount, Gain, IntegrationTime,
     InterruptStatus, PowerSavingMode, SlaveAddr, Veml6030,
 };
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 struct Register;
 impl Register {
@@ -60,7 +60,7 @@ impl<I2C> Veml6030<I2C> {
 
 impl<I2C, E> Veml6030<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Enable the device.
     ///
@@ -207,7 +207,7 @@ where
 
 impl<I2C, E> Veml6030<I2C>
 where
-    I2C: i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Read whether an interrupt has occurred.
     ///

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -3,7 +3,11 @@ use crate::{
     calculate_raw_threshold_value, Config, Error, FaultCount, Gain, IntegrationTime,
     InterruptStatus, PowerSavingMode, SlaveAddr, Veml6030,
 };
-use embedded_hal::i2c;
+
+#[cfg(not(feature = "async"))]
+use embedded_hal::i2c::I2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
 
 struct Register;
 impl Register {
@@ -58,28 +62,37 @@ impl<I2C> Veml6030<I2C> {
     }
 }
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Veml6030",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
+
 impl<I2C, E> Veml6030<I2C>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
     /// Enable the device.
     ///
     /// Note that when activating the sensor a wait time of 4 ms should be
     /// observed before the first measurement is picked up to allow for a
     /// correct start of the signal processor and oscillator.
-    pub fn enable(&mut self) -> Result<(), Error<E>> {
+    pub async fn enable(&mut self) -> Result<(), Error<E>> {
         let config = self.config.with_low(BitFlags::ALS_SD);
-        self.set_config(config)
+        self.set_config(config).await
     }
 
     /// Disable the device (shutdown).
-    pub fn disable(&mut self) -> Result<(), Error<E>> {
+    pub async fn disable(&mut self) -> Result<(), Error<E>> {
         let config = self.config.with_high(BitFlags::ALS_SD);
-        self.set_config(config)
+        self.set_config(config).await
     }
 
     /// Set the integration time.
-    pub fn set_integration_time(&mut self, it: IntegrationTime) -> Result<(), Error<E>> {
+    pub async fn set_integration_time(&mut self, it: IntegrationTime) -> Result<(), Error<E>> {
         let mask = match it {
             IntegrationTime::Ms25 => 0b1100,
             IntegrationTime::Ms50 => 0b1000,
@@ -89,13 +102,13 @@ where
             IntegrationTime::Ms800 => 0b0011,
         };
         let config = self.config.bits & !(0b1111 << 6) | (mask << 6);
-        self.set_config(Config { bits: config })?;
+        self.set_config(Config { bits: config }).await?;
         self.it = it;
         Ok(())
     }
 
     /// Set the gain.
-    pub fn set_gain(&mut self, gain: Gain) -> Result<(), Error<E>> {
+    pub async fn set_gain(&mut self, gain: Gain) -> Result<(), Error<E>> {
         let mask = match gain {
             Gain::One => 0,
             Gain::Two => 1,
@@ -103,14 +116,14 @@ where
             Gain::OneQuarter => 3,
         };
         let config = self.config.bits & !(0b11 << 11) | (mask << 11);
-        self.set_config(Config { bits: config })?;
+        self.set_config(Config { bits: config }).await?;
         self.gain = gain;
         Ok(())
     }
 
     /// Set the number of times a threshold crossing must happen consecutively
     /// to trigger an interrupt.
-    pub fn set_fault_count(&mut self, fc: FaultCount) -> Result<(), Error<E>> {
+    pub async fn set_fault_count(&mut self, fc: FaultCount) -> Result<(), Error<E>> {
         let mask = match fc {
             FaultCount::One => 0,
             FaultCount::Two => 1,
@@ -118,29 +131,29 @@ where
             FaultCount::Eight => 3,
         };
         let config = self.config.bits & !(0b11 << 4) | (mask << 4);
-        self.set_config(Config { bits: config })
+        self.set_config(Config { bits: config }).await
     }
 
     /// Enable interrupt generation.
-    pub fn enable_interrupts(&mut self) -> Result<(), Error<E>> {
+    pub async fn enable_interrupts(&mut self) -> Result<(), Error<E>> {
         let config = self.config.with_high(BitFlags::ALS_INT_EN);
-        self.set_config(config)
+        self.set_config(config).await
     }
 
     /// Disable interrupt generation.
-    pub fn disable_interrupts(&mut self) -> Result<(), Error<E>> {
+    pub async fn disable_interrupts(&mut self) -> Result<(), Error<E>> {
         let config = self.config.with_low(BitFlags::ALS_INT_EN);
-        self.set_config(config)
+        self.set_config(config).await
     }
 
     /// Set the ALS high threshold in raw format
-    pub fn set_high_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<E>> {
-        self.write_register(Register::ALS_WH, threshold)
+    pub async fn set_high_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<E>> {
+        self.write_register(Register::ALS_WH, threshold).await
     }
 
     /// Set the ALS low threshold in raw format
-    pub fn set_low_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<E>> {
-        self.write_register(Register::ALS_WL, threshold)
+    pub async fn set_low_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<E>> {
+        self.write_register(Register::ALS_WL, threshold).await
     }
 
     /// Set the ALS high threshold in lux.
@@ -148,9 +161,9 @@ where
     /// For values higher than 1000 lx and 1/4 or 1/8 gain,
     /// the inverse of the compensation formula is applied (this involves
     /// quite some math).
-    pub fn set_high_threshold_lux(&mut self, lux: f32) -> Result<(), Error<E>> {
+    pub async fn set_high_threshold_lux(&mut self, lux: f32) -> Result<(), Error<E>> {
         let raw = self.calculate_raw_threshold_value(lux);
-        self.write_register(Register::ALS_WH, raw)
+        self.write_register(Register::ALS_WH, raw).await
     }
 
     /// Set the ALS low threshold in lux.
@@ -158,9 +171,9 @@ where
     /// For values higher than 1000 lx and 1/4 or 1/8 gain,
     /// the inverse of the compensation formula is applied (this involves
     /// quite some math).
-    pub fn set_low_threshold_lux(&mut self, lux: f32) -> Result<(), Error<E>> {
+    pub async fn set_low_threshold_lux(&mut self, lux: f32) -> Result<(), Error<E>> {
         let raw = self.calculate_raw_threshold_value(lux);
-        self.write_register(Register::ALS_WL, raw)
+        self.write_register(Register::ALS_WL, raw).await
     }
 
     /// Calculate raw value for threshold applying compensation if necessary.
@@ -176,7 +189,7 @@ where
     }
 
     /// Enable the power-saving mode
-    pub fn enable_power_saving(&mut self, psm: PowerSavingMode) -> Result<(), Error<E>> {
+    pub async fn enable_power_saving(&mut self, psm: PowerSavingMode) -> Result<(), Error<E>> {
         let mask = match psm {
             PowerSavingMode::One => 0,
             PowerSavingMode::Two => 1,
@@ -184,38 +197,34 @@ where
             PowerSavingMode::Four => 3,
         };
         let value = BitFlags::PSM_EN | (mask << 1);
-        self.write_register(Register::PSM, value)
+        self.write_register(Register::PSM, value).await
     }
 
     /// Disable the power-saving mode
-    pub fn disable_power_saving(&mut self) -> Result<(), Error<E>> {
-        self.write_register(Register::PSM, 0)
+    pub async fn disable_power_saving(&mut self) -> Result<(), Error<E>> {
+        self.write_register(Register::PSM, 0).await
     }
 
-    fn set_config(&mut self, config: Config) -> Result<(), Error<E>> {
-        self.write_register(Register::ALS_CONF, config.bits)?;
+    async fn set_config(&mut self, config: Config) -> Result<(), Error<E>> {
+        self.write_register(Register::ALS_CONF, config.bits).await?;
         self.config = config;
         Ok(())
     }
 
-    fn write_register(&mut self, register: u8, value: u16) -> Result<(), Error<E>> {
+    async fn write_register(&mut self, register: u8, value: u16) -> Result<(), Error<E>> {
         self.i2c
             .write(self.address, &[register, value as u8, (value >> 8) as u8])
+            .await
             .map_err(Error::I2C)
     }
-}
 
-impl<I2C, E> Veml6030<I2C>
-where
-    I2C: i2c::I2c<Error = E>,
-{
     /// Read whether an interrupt has occurred.
     ///
     /// Note that the interrupt status is updated at the same rate as the
     /// measurements. Once triggered, flags will stay true until a measurement
     /// is taken which does not exceed the threshold.
-    pub fn read_interrupt_status(&mut self) -> Result<InterruptStatus, Error<E>> {
-        let data = self.read_register(Register::ALS_INT)?;
+    pub async fn read_interrupt_status(&mut self) -> Result<InterruptStatus, Error<E>> {
+        let data = self.read_register(Register::ALS_INT).await?;
         Ok(InterruptStatus {
             was_too_low: (data & BitFlags::INT_TH_LOW) != 0,
             was_too_high: (data & BitFlags::INT_TH_HIGH) != 0,
@@ -223,8 +232,8 @@ where
     }
 
     /// Read ALS high resolution output data in raw format
-    pub fn read_raw(&mut self) -> Result<u16, Error<E>> {
-        self.read_register(Register::ALS)
+    pub async fn read_raw(&mut self) -> Result<u16, Error<E>> {
+        self.read_register(Register::ALS).await
     }
 
     /// Read ALS high resolution output data converted to lux
@@ -232,8 +241,8 @@ where
     /// For values higher than 1000 lx and 1/4 or 1/8 gain,
     /// the following compensation formula is applied:
     /// `lux = 6.0135e-13*(lux^4) - 9.3924e-9*(lux^3) + 8.1488e-5*(lux^2) + 1.0023*lux`
-    pub fn read_lux(&mut self) -> Result<f32, Error<E>> {
-        let raw = self.read_register(Register::ALS)?;
+    pub async fn read_lux(&mut self) -> Result<f32, Error<E>> {
+        let raw = self.read_register(Register::ALS).await?;
         Ok(self.convert_raw_als_to_lux(raw))
     }
 
@@ -250,14 +259,15 @@ where
     }
 
     /// Read white channel measurement
-    pub fn read_white(&mut self) -> Result<u16, Error<E>> {
-        self.read_register(Register::WHITE)
+    pub async fn read_white(&mut self) -> Result<u16, Error<E>> {
+        self.read_register(Register::WHITE).await
     }
 
-    fn read_register(&mut self, register: u8) -> Result<u16, Error<E>> {
+    async fn read_register(&mut self, register: u8) -> Result<u16, Error<E>> {
         let mut data = [0; 2];
         self.i2c
             .write_read(self.address, &[register], &mut data)
+            .await
             .map_err(Error::I2C)
             .and(Ok(u16::from(data[0]) | (u16::from(data[1]) << 8)))
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use veml6030::{SlaveAddr, Veml6030};
 
 pub const DEV_ADDR: u8 = 0x10;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 use veml6030::{
     FaultCount as FC, Gain, IntegrationTime as IT, InterruptStatus, PowerSavingMode as PSM,
 };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,14 +14,19 @@ fn can_create_and_destroy() {
 
 macro_rules! set_test {
     ($name:ident, $method:ident, $register:ident, $value:expr $(, $arg:expr)*) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async"))),
+            async(feature = "async", keep_self)
+        )]
+        #[cfg_attr(feature = "async", tokio::test)]
+        #[cfg_attr(not(feature = "async"), test)]
+        async fn $name() {
             let transactions = [I2cTrans::write(
                 DEV_ADDR,
                 vec![Reg::$register, $value as u8, ($value >> 8) as u8],
             )];
             let mut sensor = new(&transactions);
-            sensor.$method($($arg),*).unwrap();
+            sensor.$method($($arg),*).await.unwrap();
             destroy(sensor);
         }
     };
@@ -116,15 +121,20 @@ set_test!(disable_psm, disable_power_saving, PSM, 0);
 
 macro_rules! get_test {
     ($name:ident, $method:ident, $register:ident, $value:expr, $expected:expr) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async"))),
+            async(feature = "async", keep_self)
+        )]
+        #[cfg_attr(feature = "async", tokio::test)]
+        #[cfg_attr(not(feature = "async"), test)]
+        async fn $name() {
             let transactions = [I2cTrans::write_read(
                 DEV_ADDR,
                 vec![Reg::$register],
                 vec![$value as u8, ($value >> 8) as u8],
             )];
             let mut sensor = new(&transactions);
-            let result = sensor.$method().unwrap();
+            let result = sensor.$method().await.unwrap();
             assert_eq!($expected, result);
             destroy(sensor);
         }
@@ -176,8 +186,13 @@ get_test!(read_white, read_white, WHITE, 0xABCD_u16, 0xABCD);
 
 macro_rules! read_lux_test {
     ($name:ident, $it:ident, $gain:ident, $config1:expr, $config2:expr, $als:expr, $expected:expr) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async"))),
+            async(feature = "async", keep_self)
+        )]
+        #[cfg_attr(feature = "async", tokio::test)]
+        #[cfg_attr(not(feature = "async"), test)]
+        async fn $name() {
             let transactions = [
                 I2cTrans::write(
                     DEV_ADDR,
@@ -194,9 +209,9 @@ macro_rules! read_lux_test {
                 ),
             ];
             let mut sensor = new(&transactions);
-            sensor.set_integration_time(IT::$it).unwrap();
-            sensor.set_gain(Gain::$gain).unwrap();
-            let result = sensor.read_lux().unwrap();
+            sensor.set_integration_time(IT::$it).await.unwrap();
+            sensor.set_gain(Gain::$gain).await.unwrap();
+            let result = sensor.read_lux().await.unwrap();
             assert!($expected - 0.5 < result);
             assert!($expected + 0.5 > result);
             destroy(sensor);
@@ -287,8 +302,13 @@ set_test!(low_th_lux, set_low_threshold_lux, ALS_WL, 1480_u16, 85.248);
 
 macro_rules! set_th_test {
     ($name:ident, $method:ident, $register:ident) => {
-        #[test]
-        fn $name() {
+        #[maybe_async_cfg::maybe(
+            sync(cfg(not(feature = "async"))),
+            async(feature = "async", keep_self)
+        )]
+        #[cfg_attr(feature = "async", tokio::test)]
+        #[cfg_attr(not(feature = "async"), test)]
+        async fn $name() {
             let config1 = CFG_DEFAULT | (0b1100 << 6);
             let config2 = config1 | 2 << 11;
             let als_raw = 1479;
@@ -307,9 +327,9 @@ macro_rules! set_th_test {
                 ),
             ];
             let mut sensor = new(&transactions);
-            sensor.set_integration_time(IT::Ms25).unwrap();
-            sensor.set_gain(Gain::OneEighth).unwrap();
-            sensor.$method(3183.247).unwrap();
+            sensor.set_integration_time(IT::Ms25).await.unwrap();
+            sensor.set_gain(Gain::OneEighth).await.unwrap();
+            sensor.$method(3183.247).await.unwrap();
             destroy(sensor);
         }
     };


### PR DESCRIPTION
This has 5 commits

1. update to embedded-hal 1.0
2. add async support via maybe-async (adding embedded-hal-async)
3. fix tests
4. update to latest libm
5. update linux-embedded-hal

For the libm update `libm::F64Ext` was removed.  I turned an AI loose on `inverse_high_lux_correction()` to update it (I in no way wanted to attempt it.)  The tests pass and I think it did a passible job but I can drop that commit if you want.
